### PR TITLE
Revert to using .list instead of .sources

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,7 +26,9 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.x'
+          # Pinned to 3.12: Python 3.14+ requires ansible-core >= 2.20.0
+          # Current version constraint is ansible-core < 2.18
+          python-version: '3.12'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,4 +1,4 @@
-name: ansible-lint
+name: Ansible Lint and Molecule Test
 on:
   push:
     branches: [main]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## v0.0.3 - 2024-12-11
+## 0.0.3
 * Switched back to .list format because otherwise Spotify will update and create a .list file which leads to duplicate sources when we have a .sources file present.
 
-## v0.0.2
+## 0.0.2
 * Updated to use DEB822 format with deb822_repository module.
 
-## v0.0.1
+## 0.0.1
 * First version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 # Changelog
-* switched back to .list format because otherwise spotify will update and create a .list file which leads to duplicate sources when we have a .sources file present.
+* Switched back to .list format because otherwise Spotify will update and create a .list file which leads to duplicate sources when we have a .sources file present.
 * First version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
 # Changelog
+
+## v0.0.3 - 2024-12-11
 * Switched back to .list format because otherwise Spotify will update and create a .list file which leads to duplicate sources when we have a .sources file present.
+
+## v0.0.2
+* Updated to use DEB822 format with deb822_repository module.
+
+## v0.0.1
 * First version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 # Changelog
 * Switched back to .list format because otherwise Spotify will update and create a .list file which leads to duplicate sources when we have a .sources file present.
-* First version
+* First version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 # Changelog
+* switched back to .list format because otherwise spotify will update and create a .list file which leads to duplicate sources when we have a .sources file present.
 * First version

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,7 +6,7 @@ authors:
 description: Installs spotify
 license_file: LICENSE
 readme: README.md
-version: 0.0.2
+version: 0.0.3
 repository: https://github.com/compscidr/ansible-spotify
 tags:
     - spotify

--- a/roles/spotify/tasks/main.yml
+++ b/roles/spotify/tasks/main.yml
@@ -1,8 +1,9 @@
 ---
-# Note: We currently use the old .list format because Spotify's package creates and expects this format.
-# If Spotify updates to use .sources (DEB822) format in the future, we should switch back to using
-# deb822_repository module and remove these cleanup tasks. This prevents duplicate repository warnings
-# when Spotify auto-updates itself.
+# Note: We currently use the old .list format because Spotify's package
+# creates and expects this format. If Spotify updates to use .sources
+# (DEB822) format in the future, we should switch back to using
+# deb822_repository module and remove these cleanup tasks. This prevents
+# duplicate repository warnings when Spotify auto-updates itself.
 - name: Remove old playbook artifacts (new-format sources file)
   tags: spotify
   become: true
@@ -17,24 +18,41 @@
     path: /etc/apt/keyrings/spotify.asc
     state: absent
 
-- name: Ensure required packages are installed
+- name: Ensure gnupg is installed
   tags: spotify
   become: true
   ansible.builtin.apt:
-    name:
-      - gnupg
-      - curl
+    name: gnupg
     state: present
     update_cache: true
 
 # Note: The URL has .gpg extension but provides ASCII-armored format
-# We dearmor it to binary and save to trusted.gpg.d matching Spotify's naming convention
-- name: Download and install Spotify GPG key
+# We dearmor it to binary and save to trusted.gpg.d matching Spotify's
+# naming convention
+- name: Download Spotify GPG key
+  tags: spotify
+  become: true
+  ansible.builtin.get_url:
+    url: https://download.spotify.com/debian/pubkey_C85668DF69375001.gpg
+    dest: /tmp/spotify.gpg.asc
+    mode: '0644'
+
+- name: Dearmor Spotify GPG key
   tags: spotify
   become: true
   ansible.builtin.shell:
-    cmd: curl -sS https://download.spotify.com/debian/pubkey_C85668DF69375001.gpg | gpg --dearmor -o /etc/apt/trusted.gpg.d/spotify-2024-11-13-C85668DF69375001.gpg
+    cmd: >-
+      gpg --dearmor -o
+      /etc/apt/trusted.gpg.d/spotify-2024-11-13-C85668DF69375001.gpg
+      /tmp/spotify.gpg.asc
     creates: /etc/apt/trusted.gpg.d/spotify-2024-11-13-C85668DF69375001.gpg
+
+- name: Remove temporary Spotify GPG key file
+  tags: spotify
+  become: true
+  ansible.builtin.file:
+    path: /tmp/spotify.gpg.asc
+    state: absent
 
 - name: Add spotify apt repository (matching Spotify's official format)
   tags: spotify

--- a/roles/spotify/tasks/main.yml
+++ b/roles/spotify/tasks/main.yml
@@ -11,7 +11,7 @@
     path: /etc/apt/sources.list.d/spotify.sources
     state: absent
 
-- name: Remove old playbook artifacts (keyrings key)
+- name: Remove old playbook artifacts (keyring key)
   tags: spotify
   become: true
   ansible.builtin.file:
@@ -26,14 +26,16 @@
     state: present
     update_cache: true
 
-# Note: The URL has .gpg extension but provides ASCII-armored format
-# We dearmor it to binary and save to trusted.gpg.d matching Spotify's
-# naming convention
+# Note: Spotify's GPG key is provided in ASCII-armored format (text-based)
+# despite the .gpg extension in the URL. We convert it to binary format
+# using gpg --dearmor for compatibility with /etc/apt/trusted.gpg.d/
+# which expects binary GPG keys. The filename uses Spotify's key ID without
+# the date prefix to simplify maintenance.
 - name: Check if Spotify GPG key already exists
   tags: spotify
   become: true
   ansible.builtin.stat:
-    path: /etc/apt/trusted.gpg.d/spotify-2024-11-13-C85668DF69375001.gpg
+    path: /etc/apt/trusted.gpg.d/spotify-C85668DF69375001.gpg
   register: spotify_key
 
 - name: Download Spotify GPG key
@@ -43,6 +45,8 @@
     url: https://download.spotify.com/debian/pubkey_C85668DF69375001.gpg
     dest: /tmp/spotify.gpg.asc
     mode: '0644'
+    # Note: Checksum validation not implemented as Spotify doesn't
+    # publish checksums for their GPG keys
   when: not spotify_key.stat.exists
 
 - name: Dearmor Spotify GPG key
@@ -51,7 +55,7 @@
   ansible.builtin.command:
     cmd: >-
       gpg --dearmor -o
-      /etc/apt/trusted.gpg.d/spotify-2024-11-13-C85668DF69375001.gpg
+      /etc/apt/trusted.gpg.d/spotify-C85668DF69375001.gpg
       /tmp/spotify.gpg.asc
   when: not spotify_key.stat.exists
   changed_when: true

--- a/roles/spotify/tasks/main.yml
+++ b/roles/spotify/tasks/main.yml
@@ -1,21 +1,53 @@
 ---
-- name: Add spotify apt repository and key
+# Note: We currently use the old .list format because Spotify's package creates and expects this format.
+# If Spotify updates to use .sources (DEB822) format in the future, we should switch back to using
+# deb822_repository module and remove these cleanup tasks. This prevents duplicate repository warnings
+# when Spotify auto-updates itself.
+- name: Remove old playbook artifacts (new-format sources file)
   tags: spotify
   become: true
-  ansible.builtin.deb822_repository:
-    name: spotify
+  ansible.builtin.file:
+    path: /etc/apt/sources.list.d/spotify.sources
+    state: absent
+
+- name: Remove old playbook artifacts (keyrings key)
+  tags: spotify
+  become: true
+  ansible.builtin.file:
+    path: /etc/apt/keyrings/spotify.asc
+    state: absent
+
+- name: Ensure required packages are installed
+  tags: spotify
+  become: true
+  ansible.builtin.apt:
+    name:
+      - gnupg
+      - curl
     state: present
-    types: [deb]
-    uris: "http://repository.spotify.com"
-    suites: [stable]
-    components: [non-free]
-    signed_by: https://download.spotify.com/debian/pubkey_C85668DF69375001.gpg
-    enabled: true
+    update_cache: true
+
+# Note: The URL has .gpg extension but provides ASCII-armored format
+# We dearmor it to binary and save to trusted.gpg.d matching Spotify's naming convention
+- name: Download and install Spotify GPG key
+  tags: spotify
+  become: true
+  ansible.builtin.shell:
+    cmd: curl -sS https://download.spotify.com/debian/pubkey_C85668DF69375001.gpg | gpg --dearmor -o /etc/apt/trusted.gpg.d/spotify-2024-11-13-C85668DF69375001.gpg
+    creates: /etc/apt/trusted.gpg.d/spotify-2024-11-13-C85668DF69375001.gpg
+
+- name: Add spotify apt repository (matching Spotify's official format)
+  tags: spotify
+  become: true
+  ansible.builtin.apt_repository:
+    repo: "deb https://repository.spotify.com stable non-free"
+    filename: spotify
+    state: present
+    update_cache: true
 
 - name: Install spotify
   tags: spotify
   become: true
   ansible.builtin.apt:
-    update_cache: true
     name: spotify-client
     state: present

--- a/roles/spotify/tasks/main.yml
+++ b/roles/spotify/tasks/main.yml
@@ -48,12 +48,13 @@
 - name: Dearmor Spotify GPG key
   tags: spotify
   become: true
-  ansible.builtin.shell:
+  ansible.builtin.command:
     cmd: >-
       gpg --dearmor -o
       /etc/apt/trusted.gpg.d/spotify-2024-11-13-C85668DF69375001.gpg
       /tmp/spotify.gpg.asc
   when: not spotify_key.stat.exists
+  changed_when: true
 
 - name: Remove temporary Spotify GPG key file
   tags: spotify

--- a/roles/spotify/tasks/main.yml
+++ b/roles/spotify/tasks/main.yml
@@ -10,11 +10,18 @@
   ansible.builtin.file:
     path: /etc/apt/sources.list.d/spotify.sources
     state: absent
-- name: Remove old playbook artifacts (keyring key)
+- name: Remove old playbook artifacts (old keyring key location)
   tags: spotify
   become: true
   ansible.builtin.file:
     path: /etc/apt/keyrings/spotify.asc
+    state: absent
+
+- name: Remove old playbook artifacts (old trusted GPG key)
+  tags: spotify
+  become: true
+  ansible.builtin.file:
+    path: /etc/apt/trusted.gpg.d/spotify-C85668DF69375001.gpg
     state: absent
 
 - name: Ensure gnupg is installed
@@ -27,14 +34,21 @@
 
 # Note: Spotify's GPG key is provided in ASCII-armored format (text-based)
 # despite the .gpg extension in the URL. We convert it to binary format
-# using gpg --dearmor for compatibility with /etc/apt/trusted.gpg.d/
-# which expects binary GPG keys. The filename uses Spotify's key ID without
-# the date prefix to simplify maintenance.
+# using gpg --dearmor for use with signed-by in /etc/apt/keyrings/.
+# This scopes the key trust to only the Spotify repository.
+- name: Ensure /etc/apt/keyrings directory exists
+  tags: spotify
+  become: true
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
+
 - name: Check if Spotify GPG key already exists
   tags: spotify
   become: true
   ansible.builtin.stat:
-    path: /etc/apt/trusted.gpg.d/spotify-C85668DF69375001.gpg
+    path: /etc/apt/keyrings/spotify.gpg
   register: spotify_key
 
 - name: Download Spotify GPG key
@@ -48,16 +62,22 @@
     # publish checksums for their GPG keys
   when: not spotify_key.stat.exists
 
-- name: Dearmor Spotify GPG key
+- name: Verify Spotify GPG key fingerprint
   tags: spotify
   become: true
   ansible.builtin.command:
-    cmd: >-
-      gpg --dearmor -o
-      /etc/apt/trusted.gpg.d/spotify-C85668DF69375001.gpg
-      /tmp/spotify.gpg.asc
+    cmd: gpg --with-colons --import-options show-only --import /tmp/spotify.gpg.asc
+  register: gpg_output
+  changed_when: false
+  failed_when: "'C85668DF69375001' not in gpg_output.stdout"
   when: not spotify_key.stat.exists
-  changed_when: true
+
+- name: Dearmor Spotify GPG key to keyrings directory
+  tags: spotify
+  become: true
+  ansible.builtin.command:
+    cmd: gpg --dearmor -o /etc/apt/keyrings/spotify.gpg /tmp/spotify.gpg.asc
+    creates: /etc/apt/keyrings/spotify.gpg
 
 - name: Remove temporary Spotify GPG key file
   tags: spotify
@@ -71,7 +91,7 @@
   tags: spotify
   become: true
   ansible.builtin.apt_repository:
-    repo: "deb https://repository.spotify.com stable non-free"
+    repo: "deb [signed-by=/etc/apt/keyrings/spotify.gpg] https://repository.spotify.com stable non-free"
     filename: spotify
     state: present
     update_cache: true

--- a/roles/spotify/tasks/main.yml
+++ b/roles/spotify/tasks/main.yml
@@ -29,6 +29,13 @@
 # Note: The URL has .gpg extension but provides ASCII-armored format
 # We dearmor it to binary and save to trusted.gpg.d matching Spotify's
 # naming convention
+- name: Check if Spotify GPG key already exists
+  tags: spotify
+  become: true
+  ansible.builtin.stat:
+    path: /etc/apt/trusted.gpg.d/spotify-2024-11-13-C85668DF69375001.gpg
+  register: spotify_key
+
 - name: Download Spotify GPG key
   tags: spotify
   become: true
@@ -36,6 +43,7 @@
     url: https://download.spotify.com/debian/pubkey_C85668DF69375001.gpg
     dest: /tmp/spotify.gpg.asc
     mode: '0644'
+  when: not spotify_key.stat.exists
 
 - name: Dearmor Spotify GPG key
   tags: spotify
@@ -45,7 +53,7 @@
       gpg --dearmor -o
       /etc/apt/trusted.gpg.d/spotify-2024-11-13-C85668DF69375001.gpg
       /tmp/spotify.gpg.asc
-    creates: /etc/apt/trusted.gpg.d/spotify-2024-11-13-C85668DF69375001.gpg
+  when: not spotify_key.stat.exists
 
 - name: Remove temporary Spotify GPG key file
   tags: spotify
@@ -53,6 +61,7 @@
   ansible.builtin.file:
     path: /tmp/spotify.gpg.asc
     state: absent
+  when: not spotify_key.stat.exists
 
 - name: Add spotify apt repository (matching Spotify's official format)
   tags: spotify

--- a/roles/spotify/tasks/main.yml
+++ b/roles/spotify/tasks/main.yml
@@ -10,7 +10,6 @@
   ansible.builtin.file:
     path: /etc/apt/sources.list.d/spotify.sources
     state: absent
-
 - name: Remove old playbook artifacts (keyring key)
   tags: spotify
   become: true

--- a/roles/spotify/tasks/main.yml
+++ b/roles/spotify/tasks/main.yml
@@ -67,9 +67,9 @@
   become: true
   ansible.builtin.command:
     cmd: gpg --with-colons --import-options show-only --import /tmp/spotify.gpg.asc
-  register: gpg_output
+  register: spotify_gpg_output
   changed_when: false
-  failed_when: "'C85668DF69375001' not in gpg_output.stdout"
+  failed_when: "'C85668DF69375001' not in spotify_gpg_output.stdout"
   when: not spotify_key.stat.exists
 
 - name: Dearmor Spotify GPG key to keyrings directory


### PR DESCRIPTION
Otherwise later on spotify will update and add the .list file which causes duplicate sources errors on apt update