### PR TITLE
fix: update expired Spotify GPG signing key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.5
+* Updated expired Spotify GPG signing key from C85668DF69375001 to 5384CE82BA52C83A
+* Added automatic detection and removal of the old expired key on existing installations
+
 ## 0.0.4
 * Fixed the apt source to remove the signed-by
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,7 +6,7 @@ authors:
 description: Installs spotify
 license_file: LICENSE
 readme: README.md
-version: 0.0.4
+version: 0.0.5
 repository: https://github.com/compscidr/ansible-spotify
 tags:
     - spotify

--- a/roles/spotify/tasks/main.yml
+++ b/roles/spotify/tasks/main.yml
@@ -58,11 +58,36 @@
     path: /etc/apt/trusted.gpg.d/spotify.gpg
   register: spotify_key
 
+- name: Check if existing Spotify GPG key contains expired key
+  tags: spotify
+  become: true
+  ansible.builtin.command:
+    cmd: gpg --no-default-keyring --keyring /etc/apt/trusted.gpg.d/spotify.gpg --list-keys C85668DF69375001
+  register: spotify_old_key_check
+  changed_when: false
+  failed_when: false
+  when: spotify_key.stat.exists
+
+- name: Remove expired Spotify GPG key (C85668DF69375001)
+  tags: spotify
+  become: true
+  ansible.builtin.file:
+    path: /etc/apt/trusted.gpg.d/spotify.gpg
+    state: absent
+  when: spotify_key.stat.exists and spotify_old_key_check.rc == 0
+
+- name: Re-check if Spotify GPG key exists after cleanup
+  tags: spotify
+  become: true
+  ansible.builtin.stat:
+    path: /etc/apt/trusted.gpg.d/spotify.gpg
+  register: spotify_key
+
 - name: Download Spotify GPG key
   tags: spotify
   become: true
   ansible.builtin.get_url:
-    url: https://download.spotify.com/debian/pubkey_C85668DF69375001.gpg
+    url: https://download.spotify.com/debian/pubkey_5384CE82BA52C83A.gpg
     dest: /tmp/spotify.gpg.asc
     mode: '0644'
     # Note: Checksum validation not implemented as Spotify doesn't
@@ -76,7 +101,7 @@
     cmd: gpg --with-colons --import-options show-only --import /tmp/spotify.gpg.asc
   register: spotify_gpg_output
   changed_when: false
-  failed_when: "'C85668DF69375001' not in spotify_gpg_output.stdout"
+  failed_when: "'5384CE82BA52C83A' not in spotify_gpg_output.stdout"
   when: not spotify_key.stat.exists
 
 - name: Dearmor Spotify GPG key to trusted.gpg.d directory


### PR DESCRIPTION
## Summary
- Spotify rotated their apt repository signing key. The old key `C85668DF69375001` has expired, causing `apt update` failures with `EXPKEYSIG` errors.
- Updates the download URL and fingerprint verification to use the new key `5384CE82BA52C83A`
- Adds a task to detect and remove the old expired key so existing installations get the new key on next run

## Test plan
- [ ] Run the role on a machine that has the old expired key installed — verify the old key is removed and the new key is downloaded
- [ ] Run the role on a fresh machine — verify the new key is installed and `apt update` succeeds
- [ ] Run the role twice — verify idempotency (second run makes no changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)