### PR TITLE
Update to Python 3.14 and ansible-core 2.20

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,5 +32,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install "ansible-core>=2.20,<2.21" molecule molecule-docker passlib
       - name: Run Molecule Test
+        env:
+          # molecule-docker's destroy playbook uses bare string conditionals
+          # which ansible-core 2.20 rejects by default
+          ANSIBLE_CONDITIONAL_BARE_VARS: "false"
         run: |
           molecule test --all

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,11 +30,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install "ansible-core>=2.20,<2.21" molecule molecule-docker passlib
+          pip install "ansible-core>=2.20,<2.21" "molecule>=25.1.0" "molecule-plugins[docker]>=25.8.12" docker passlib
       - name: Run Molecule Test
-        env:
-          # molecule-docker's destroy playbook uses bare string conditionals
-          # which ansible-core 2.20 rejects by default
-          ANSIBLE_CONDITIONAL_BARE_VARS: "false"
         run: |
           molecule test --all

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,13 +26,11 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          # Pinned to 3.12: Python 3.14+ requires ansible-core >= 2.20.0
-          # Current version constraint is ansible-core < 2.18
-          python-version: '3.12'
+          python-version: '3.14'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install "ansible-core<2.18" molecule molecule-docker passlib
+          pip install "ansible-core>=2.20,<2.21" molecule molecule-docker passlib
       - name: Run Molecule Test
         run: |
           molecule test --all


### PR DESCRIPTION
## Summary
- Update ansible-core constraint from `<2.18` to `>=2.20,<2.21`
- Update Python from 3.12 to 3.14 (now compatible with ansible-core 2.20)
- Remove the outdated pin comment

Once this merges, PR #11 (Renovate Python 3.14 bump) can be closed as superseded.

## Test plan
- [ ] Molecule test passes with Python 3.14 + ansible-core 2.20

🤖 Generated with [Claude Code](https://claude.com/claude-code)